### PR TITLE
Bugfix: do not remove oldOrders, if no deeplink filter set

### DIFF
--- a/changelog/_unreleased/2021-09-27-bugfix-show-all-orders-in-storefront-history.md
+++ b/changelog/_unreleased/2021-09-27-bugfix-show-all-orders-in-storefront-history.md
@@ -1,0 +1,13 @@
+---
+title: Bugfix: show all orders in storefront history
+author: Marcel Tams
+author_email: marcel.tams@networkteam.com 
+author_github: amtee
+---
+# Core
+* In method `load` in file `src/Core/Checkout/Order/SalesChannel/OrderRoute.php`  there
+was a misleading condition. Any `$deepLinkFilter` but false led to removing `orders` with last updated 
+  or created older than 30 days the latest order.
+  
+  
+

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -114,7 +114,7 @@ class OrderRoute extends AbstractOrderRoute
         $orders = $this->orderRepository->search($criteria, $context->getContext());
 
         // remove old orders only if there is a deeplink filter
-        if ($deepLinkFilter === true) {
+        if ($deepLinkFilter !== null) {
             $orders = $this->filterOldOrders($orders);
         }
 

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -113,7 +113,8 @@ class OrderRoute extends AbstractOrderRoute
 
         $orders = $this->orderRepository->search($criteria, $context->getContext());
 
-        if ($deepLinkFilter !== false) {
+        // remove old orders only if there is a deeplink filter
+        if ($deepLinkFilter === true) {
             $orders = $this->filterOldOrders($orders);
         }
 


### PR DESCRIPTION
- the given condition leads to an incomplete order history, if a customer has orders 30 days older than his latest order
- fixed by setting it to an implicit true comparison

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
